### PR TITLE
Add setting.AppSubUrl in case of different ROOT_URL and LANDING_PAGE = e...

### DIFF
--- a/modules/middleware/auth.go
+++ b/modules/middleware/auth.go
@@ -30,7 +30,7 @@ func Toggle(options *ToggleOptions) macaron.Handler {
 
 		// Checking non-logged users landing page.
 		if !ctx.IsSigned && ctx.Req.RequestURI == "/" && setting.LandingPageUrl != setting.LANDING_PAGE_HOME {
-			ctx.Redirect(string(setting.LandingPageUrl))
+			ctx.Redirect(setting.AppSubUrl + string(setting.LandingPageUrl))
 			return
 		}
 


### PR DESCRIPTION
I have an URL containing a /git/ subdirectory for the service.
If I change LANDING_PAGE to explore, I'm redirected to /explore instead /git/explore.

This patch add AppSubUrl to LANDING_PAGE.